### PR TITLE
92 revisar bandera status en queries

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,8 @@
     "swagger",
     "decorators",
     "filters",
-    "catalogs"
+    "catalogs",
+    "prisma"
   ],
   "cSpell.language": "en,es-ES"
 }

--- a/src/config/common/utils/index.ts
+++ b/src/config/common/utils/index.ts
@@ -2,3 +2,4 @@ export * from './base-response.util';
 export * from './find-all.util';
 export * from './http-exception.util';
 export * from './map.util';
+export * from './prisma.util';

--- a/src/config/common/utils/prisma.util.ts
+++ b/src/config/common/utils/prisma.util.ts
@@ -1,0 +1,26 @@
+export const removeInactive = (data: any): any => {
+  if (Array.isArray(data)) {
+    return data
+      .map(removeInactive)
+      .filter((item) => !(item && item.active === false))
+      .filter((item) => item !== null && item !== undefined);
+  } else if (typeof data === 'object' && data !== null) {
+    const newData: any = {};
+
+    for (const key in data) {
+      if (Object.prototype.hasOwnProperty.call(data, key)) {
+        const value = data[key];
+
+        newData[key] = removeInactive(value);
+      }
+    }
+
+    if (newData.active === false) {
+      return undefined;
+    }
+
+    return newData;
+  }
+
+  return data;
+};

--- a/src/config/database/constants/index.ts
+++ b/src/config/database/constants/index.ts
@@ -1,0 +1,3 @@
+export const whereActive = {
+  active: true,
+};

--- a/src/config/database/constants/index.ts
+++ b/src/config/database/constants/index.ts
@@ -1,3 +1,10 @@
 export const whereActive = {
   active: true,
 };
+
+export const operationsWithWhere = [
+  'findMany',
+  'findFirst',
+  'findUnique',
+  'findUniqueOrThrow',
+];

--- a/src/config/database/index.ts
+++ b/src/config/database/index.ts
@@ -1,2 +1,3 @@
 export * from './prisma.module';
 export * from './services';
+export * from './constants';

--- a/src/config/database/services/prisma.service.ts
+++ b/src/config/database/services/prisma.service.ts
@@ -3,6 +3,7 @@
 database connections in a NestJS application. */
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
+import { operationsWithWhere, whereActive } from '../constants';
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {
@@ -18,6 +19,46 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
    */
   async onModuleInit() {
     await this.$connect();
+
+    this.$use(async (params, next) => {
+      if (operationsWithWhere.includes(params.action)) {
+        if (!params.args.where) {
+          params.args.where = {};
+        }
+
+        params.args.where = {
+          ...params.args.where,
+          ...whereActive,
+        };
+        if (params.args.include || params.args.select) {
+          for (const relation in params.args.include || {}) {
+            if (
+              params.args.include[relation] &&
+              !params.args.include[relation].where
+            ) {
+              params.args.include[relation].where = {
+                ...whereActive,
+              };
+            }
+          }
+
+          for (const relation in params.args.select || {}) {
+            if (
+              params.args.select[relation] &&
+              typeof params.args.select[relation] === 'object'
+            ) {
+              if (!params.args.select[relation].where) {
+                params.args.select[relation].where = {
+                  ...whereActive,
+                };
+              }
+            }
+          }
+        }
+      }
+
+      return next(params);
+    });
 
     this.logger.log('Prisma connected');
   }

--- a/src/modules/users/helpers/user.prisma.helper.service.ts
+++ b/src/modules/users/helpers/user.prisma.helper.service.ts
@@ -17,6 +17,7 @@ import {
   IPrismaWhereFilter,
   PrismaService,
   unauthorizedExceptionMessages,
+  whereActive,
 } from '@/config';
 import { EnterprisesPrismaService } from '@/modules/enterprises';
 
@@ -101,7 +102,7 @@ export class UserPrismaService {
     const user = await this.prisma.users.findFirst({
       where: {
         email,
-        active: true,
+        ...whereActive,
       },
       select: {
         id: true,
@@ -113,11 +114,13 @@ export class UserPrismaService {
         name: true,
         lastname: true,
         roles: {
+          where: whereActive,
           select: {
             id: true,
             name: true,
             description: true,
             rolesModules: {
+              where: whereActive,
               select: {
                 id: true,
                 modules: {
@@ -132,6 +135,7 @@ export class UserPrismaService {
                   },
                 },
                 rolesModulesPermissions: {
+                  where: whereActive,
                   select: {
                     id: true,
                     idPermission: true,
@@ -171,7 +175,7 @@ export class UserPrismaService {
     const user = await this.prisma.users.findFirst({
       where: {
         email,
-        active: true,
+        ...whereActive,
       },
     });
 
@@ -194,7 +198,7 @@ export class UserPrismaService {
     const user = await this.prisma.users.findFirst({
       where: {
         id,
-        active: true,
+        ...whereActive,
       },
       select: {
         id: true,
@@ -232,7 +236,7 @@ export class UserPrismaService {
     const user = await this.prisma.users.findFirst({
       where: {
         id,
-        active: true,
+        ...whereActive,
       },
       select: {
         id: true,
@@ -244,14 +248,13 @@ export class UserPrismaService {
         idEnterprise: true,
         password: false,
         roles: {
+          where: whereActive,
           select: {
             id: true,
             name: true,
             description: true,
             rolesModules: {
-              where: {
-                active: true,
-              },
+              where: whereActive,
               select: {
                 id: true,
                 modules: {
@@ -266,6 +269,7 @@ export class UserPrismaService {
                   },
                 },
                 rolesModulesPermissions: {
+                  where: whereActive,
                   select: {
                     id: true,
                     idPermission: true,


### PR DESCRIPTION
- Resolved #92 

- Se agrego un middleware para setear un where a la consulta principal y relaciones para funcionar como defaultScope
- Se creo un helper para eliminar los activos en falso de forma manual ya que prisma no tiene soluciones ante una relacion 1:1